### PR TITLE
Add 'Sent At' timestamp column to webhook deliveries table

### DIFF
--- a/clients/apps/web/src/components/Settings/Webhook/WebhookDeliveriesTable.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookDeliveriesTable.tsx
@@ -22,6 +22,7 @@ import {
   DataTableColumnDef,
   DataTableColumnHeader,
 } from '@polar-sh/ui/components/atoms/DataTable'
+import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { CellContext } from '@tanstack/react-table'
 import { useRouter } from 'next/navigation'
 import React, { useCallback } from 'react'
@@ -195,6 +196,31 @@ const DeliveriesTable: React.FC<DeliveriesTableProps> = ({
         return <pre>{payload['type']}</pre>
       },
     },
+    {
+      accessorKey: 'created_at',
+      enableSorting: true,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Sent At" />
+      ),
+
+      cell: (props) => {
+        const { row } = props
+        const { original: delivery } = row
+
+        if (delivery.isSubRow) {
+          return null
+        }
+
+        return (
+          <FormattedDateTime
+            datetime={delivery.created_at}
+            resolution="time"
+            dateStyle="short"
+            timeStyle="short"
+          />
+        )
+      },
+    },
   ]
 
   return (
@@ -213,7 +239,7 @@ const DeliveriesTable: React.FC<DeliveriesTableProps> = ({
           getCellColSpan={(cell) => {
             if (cell.row.original.isSubRow) {
               if (cell.column.id === 'id') {
-                return 4
+                return 5
               }
               // hide cell
               return 0


### PR DESCRIPTION
## Summary

Adds a "Sent At" timestamp column to the webhook deliveries table, allowing users to see when webhook deliveries were sent without having to expand each row.

## Changes

- Added `FormattedDateTime` import for proper timestamp formatting
- Added new "Sent At" column displaying `delivery.created_at` 
- Enabled sorting on the `created_at` field for better usability
- Updated `getCellColSpan` calculation from 4 to 5 columns for expanded rows
- Used short date and time format for optimal readability

## Before/After

**Before**: Users had to expand each webhook delivery row to see the "Sent at" timestamp

**After**: Timestamp is immediately visible in the main table as a dedicated column

## Testing

- [x] Component compiles successfully
- [x] ESLint passes without errors  
- [x] UI package builds successfully
- [x] FormattedDateTime component integration verified

Fixes polarsource/polar#6316